### PR TITLE
update instruction for newer webpack; mention yarn

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,17 +4,25 @@ A webpack loader for Markdown files with optional [yaml front matter][1].
 Installation
 ------------
 
-npm install markdown-with-front-matter-loader
+```
+npm install --dev markdown-with-front-matter-loader
+```
 
+or 
+
+```
+yarn add --dev markdown-with-front-matter-loader
+```
 
 Usage
 -----
+
 
 ```js
 {
   module: {
     loaders: {
-      {test: /\.md$/, loader: 'markdown-with-front-matter'},
+      {test: /\.md$/, loader: 'markdown-with-front-matter-loader'},
     ]
   }
 }


### PR DESCRIPTION
It's now necessary to mention module loader name in full. Otherwise you get an error:

```
WARNING in ./src/somedir \.md$
Module not found: Error: Can't resolve 'markdown-with-front-matter' in '/Users/user/src/project'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'markdown-with-front-matter-loader' instead of 'markdown-with-front-matter'.
 @ ./src/somedir \.md$
```